### PR TITLE
Noetic/Python3 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ include_directories(
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/ros_pytest_runner
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>ros_pytest</name>
   <version>0.1.2</version>
   <description>The ros_pytest package</description>
@@ -50,7 +50,8 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <depend>rospy</depend>
-  <depend>python-pytest</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-pytest</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-pytest</depend>
   <test_depend>rostest</test_depend>
 
 


### PR DESCRIPTION
As of the current master, `ros_pytest` installs its `ros_pytest_runner` by calling CMake's `install()` function. ROS documentation for Catkin mentions that the recommended way to install Python scripts is by using `catkin_install_python`: http://docs.ros.org/melodic/api/catkin/html/howto/format2/installing_python.html. This allows Catkin to rewrite shebangs, for instance.

Another thing that should be performed for better Python 3 compatibility is to add conditional dependencies in package.xml: http://wiki.ros.org/UsingPython3/SourceCodeChanges

This P/R contains both of these changes.