### PR TITLE
Run with stdout output instead of XML output

### DIFF
--- a/src/ros_pytest/__init__.py
+++ b/src/ros_pytest/__init__.py
@@ -18,6 +18,8 @@ def get_additional_args(argv):
     for arg in argv[1:]:
         if arg.startswith('__') or arg.startswith('--gtest_output'):
             continue
+        if arg in ['-t', '--text']:
+            arg = '-s'  # pytest alias for --capture=no
         args.append(arg)
     return args
 


### PR DESCRIPTION
Resolves #4 
Useful for debugging
Capture --text arg from rostest and inject -s (alias for --capture=no) to pytest
rostest [-t|--text] -> pytest -s